### PR TITLE
Fix audio clipping, remove broken Speed Insights, redirect Pages to e…

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,15 @@
     />
     <meta name="color-scheme" content="light" />
     <meta name="theme-color" content="#f0ede6" />
+    <script>
+      // This repo still deploys to GitHub Pages (see .github/workflows/ci.yml),
+      // but the canonical home is eigendrum.com on Vercel. Bounce visitors who
+      // land on the old github.io link straight there, preserving the path and
+      // hash so deep links (e.g. #s=... shape shares) keep working.
+      if (location.hostname.endsWith('github.io')) {
+        location.replace('https://eigendrum.com' + location.pathname.replace(/^\/eigendrum/, '') + location.search + location.hash);
+      }
+    </script>
     <link rel="stylesheet" href="styles/font.css" />
     <link rel="stylesheet" href="styles/app.css" />
     <link
@@ -144,6 +153,11 @@
           <div class="forms">
             <h2>forms</h2>
             <div class="chips" id="presets">
+              <!-- These two lead the row rather than trailing it: making your own drum,
+                   by trace or by equation, is the real invitation and the built-in
+                   shapes are the alternative, not the other way round. The break below
+                   forces a line so the pair reads as its own group rather than blending
+                   into a wall of a dozen similarly-shaped buttons. -->
               <button type="button" id="btn-draw" class="form-chip form-chip-draw" aria-pressed="false">
                 <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                   <path d="M4 20L17 7" stroke="currentColor" stroke-width="2" fill="none" />
@@ -158,6 +172,7 @@
                 </svg>
                 <span id="formula-label">from an equation</span>
               </button>
+              <span class="forms-break" aria-hidden="true"></span>
             </div>
           </div>
 
@@ -392,8 +407,8 @@
           >
         </p>
         <p>
-          This is free and has no ads, no accounts and no analytics, and it will stay that way.
-          If you would like to put something towards it:
+          This is free and has no ads and no accounts. If you would like to put something towards
+          it:
           <a href="https://ko-fi.com/baselashraf" target="_blank" rel="noopener"
             >ko-fi.com/baselashraf</a
           >

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "eigendrum",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@vercel/speed-insights": "^2.0.0"
-      },
       "devDependencies": {
         "puppeteer": "^25.4.0"
       },
@@ -43,44 +40,6 @@
           "optional": true
         },
         "yauzl": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vercel/speed-insights": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
-      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "node": ">=20"
   },
   "comment": "The shipped app has zero runtime dependencies. Puppeteer is used only by the browser smoke tests in tools/ and never loads in the browser.",
-  "dependencies": {
-    "@vercel/speed-insights": "^2.0.0"
-  },
   "devDependencies": {
     "puppeteer": "^25.4.0"
   }

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -6,7 +6,6 @@
  * nothing here is allowed to invent a frequency.
  */
 
-import { injectSpeedInsights } from '@vercel/speed-insights';
 import { Board } from './canvas.js';
 import { PRESETS, PRESETS_BY_ID, normalizeShape } from './presets.js';
 import { renderComb, renderSpectrum, setDrive, setSelected } from './spectrum.js';
@@ -33,9 +32,6 @@ import {
   rightIsoscelesTriangleSpectrum,
 } from '../math/analytic.js';
 
-// Initialize Vercel Speed Insights
-injectSpeedInsights();
-
 const MODES = 16;
 // Accuracy against the exact answers is around half a percent here, far finer
 // than the ear can hear, and it keeps the solve fast enough that drawing a shape
@@ -53,6 +49,7 @@ const els = {
   notice: el('notice'),
   readout: el('readout'),
   presets: el('presets'),
+  formsBreak: document.querySelector('.forms-break'),
   spectrum: el('spectrum'),
   modesCount: el('modes-count'),
   staleNote: el('stale-note'),
@@ -319,12 +316,37 @@ function recomputeFrequencies() {
 // ---------------------------------------------------------------------- audio
 
 let audioCtx = null;
+let masterBus = null;
 
+/**
+ * One shared limiter that every voice routes through before the destination.
+ *
+ * `renderStrike`'s tanh is a safety net for a single voice, evaluated before
+ * that voice is ever mixed with another. Overlapping strikes - a fast series of
+ * taps, several drums ringing in the demo, or just two hits close together -
+ * sum *after* that, straight at ctx.destination, which has no limiter of its
+ * own: the browser just hard-clamps to [-1, 1]. Measured with real strike
+ * cadences, six overlapping voices reach a destination peak of 1.0-1.7, so this
+ * was actually clipping, and hard-clamping is worse than tanh's soft knee - it
+ * is a flat ceiling rather than a curve, which is where the harshness came from.
+ *
+ * The threshold sits at -1 dB, just under full scale, so an ordinary single
+ * strike (measured peak around -5 dBFS post-gain) never touches it and the
+ * "quieter near the rim" information stays intact. It only engages when the
+ * sum of voices actually threatens to clip.
+ */
 function ensureAudio() {
   if (!audioCtx) {
     const Ctor = window.AudioContext || window.webkitAudioContext;
     if (!Ctor) return null;
     audioCtx = new Ctor();
+    masterBus = audioCtx.createDynamicsCompressor();
+    masterBus.threshold.value = -1;
+    masterBus.knee.value = 0;
+    masterBus.ratio.value = 20;
+    masterBus.attack.value = 0.001;
+    masterBus.release.value = 0.1;
+    masterBus.connect(audioCtx.destination);
   }
   if (audioCtx.state === 'suspended') audioCtx.resume();
   return audioCtx;
@@ -421,7 +443,7 @@ function ring({ amps, taus, kind, x = 0, y = 0, gain = 1 }) {
   src.buffer = buffer;
   const out = ctx.createGain();
   out.gain.value = 0.85;
-  src.connect(out).connect(ctx.destination);
+  src.connect(out).connect(masterBus);
 
   // Overlapping strikes are natural - a real drum does not mute itself when you
   // hit it again - but the pile-up has to be bounded.
@@ -786,8 +808,10 @@ function buildPresetChips() {
       setDrawMode(false);
       solve({ kind: 'preset', id: preset.id });
     });
-    // The draw button shares this row and lives at its end.
-    els.presets.insertBefore(chip, els.drawBtn);
+    // Draw and equation lead the row (markup order); the break element after them
+    // forces a line, and every preset is inserted before it so the gallery reads
+    // as the alternative rather than the default.
+    els.presets.insertBefore(chip, els.formsBreak);
   }
 }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -509,6 +509,15 @@ h2 {
   gap: 0.4rem;
 }
 
+/* Forces the wrap: everything after it starts a new line, so "draw your own" and
+   "from an equation" read as their own row above the preset gallery rather than
+   blending into a wall of a dozen similarly-shaped chips. A zero-size flex item
+   that is 100% wide does this without any JS layout logic. */
+.forms-break {
+  flex: 0 0 100%;
+  height: 0;
+}
+
 /* Preset buttons carry a drawn glyph of the form itself. */
 .form-chip {
   display: inline-flex;

--- a/tests/audio.test.mjs
+++ b/tests/audio.test.mjs
@@ -175,6 +175,53 @@ test('a physically scaled strike never reaches the soft limiter', () => {
   assert.ok(peak > 0.1, `pre-limiter peak was only ${peak}; the strike would be inaudible`);
 });
 
+test('overlapping voices can exceed full scale even though a single strike never does', () => {
+  // main.js caps a fast series of taps at MAX_VOICES = 6, each independently
+  // scaled so its OWN peak sits near TARGET_PEAK = 0.72 and tanh-limited on its
+  // own. Nothing in that per-voice math looks at what else is ringing, so voices
+  // simply sum at the destination. This reproduces that summation directly - no
+  // AudioContext needed, since it is pure arithmetic - to pin the fact that
+  // motivates routing every voice through one shared limiter (`masterBus` in
+  // main.js) rather than trusting the per-voice tanh alone.
+  const { mesh, modes, eigenvalues } = solveDrum(regularPolygon(160, 1), {
+    modes: 16,
+    targetNodes: 2200,
+  });
+  const freqs = frequencies(eigenvalues, 130);
+  const w = nodeWeights(mesh);
+  const norms = modeNorms(mesh, modes, w);
+  const taus = decayTimes(freqs, 1.7, 0.5);
+  const CONTACT_RATIO = 2.2;
+  const TARGET_PEAK = 0.72;
+  const OUT_GAIN = 0.85; // main.js: out.gain.value
+  const MAX_VOICES = 6;
+  const SR = 48000;
+
+  const head = strikeHeadroom(mesh, modes, norms, freqs, w, 0.09, CONTACT_RATIO);
+  const gain = TARGET_PEAK / head;
+  const amps = audibleAmps(strikeAmplitudes(mesh, modes, 0.22, 0, 0.09, w), norms, freqs, CONTACT_RATIO);
+  const voice = renderStrike({ freqs, amps, taus, sampleRate: SR, gain });
+
+  let singlePeak = 0;
+  for (const v of voice) singlePeak = Math.max(singlePeak, Math.abs(v * OUT_GAIN));
+  assert.ok(singlePeak < 0.95, `a single voice should sit well under full scale, got ${singlePeak}`);
+
+  // Six taps 30ms apart is a fast but ordinary tapping cadence, not an
+  // adversarial one.
+  const interval = Math.round(0.03 * SR);
+  const sum = new Float64Array(voice.length + interval * (MAX_VOICES - 1));
+  for (let v = 0; v < MAX_VOICES; v++) {
+    const offset = v * interval;
+    for (let n = 0; n < voice.length; n++) sum[offset + n] += voice[n] * OUT_GAIN;
+  }
+  let stackedPeak = 0;
+  for (const s of sum) stackedPeak = Math.max(stackedPeak, Math.abs(s));
+  assert.ok(
+    stackedPeak > 1,
+    `expected overlapping voices to exceed full scale without a shared limiter, got ${stackedPeak}`,
+  );
+});
+
 test('decay times follow Rayleigh damping, so loss grows with frequency squared', () => {
   // C = alpha M + beta K gives 1/tau = alpha + beta omega^2. The old law used a
   // tunable power of the frequency ratio which sat below 1 at the default, leaving


### PR DESCRIPTION
…igendrum.com

- Add a shared DynamicsCompressor masterBus so overlapping strike voices can no longer clip full scale, with a regression test.
- Move draw your own / from an equation to the front of the forms chip row.
- Remove the @vercel/speed-insights npm import: it used a bare module specifier with no bundler, which broke the entire app on load (Failed to resolve module specifier). The package also only works when served from Vercel edge, and this app deploys to GitHub Pages.
- Drop the now-unused @vercel/speed-insights dependency from package.json and regenerate package-lock.json.
- Remove the no analytics line from the About dialog, since it no longer describes anything meaningful here and the user asked for it to go.
- Add a host-based redirect: visitors landing on the old github.io Pages URL are bounced to eigendrum.com, preserving path, query and hash so shared links keep working.