### PR TITLE
Fix mobile footer ad fallback and keep live presence counter visible on phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -707,7 +707,15 @@
            visually, so its position in source order matches what a sighted reader sees. -->
       <div class="ad ad-home" data-ad="home-footer" data-ad-format="horizontal">
         <span class="ad-label">advertisement</span>
-        <div class="ad-frame"></div>
+        <div class="ad-frame">
+          <a
+            class="ad-direct ad-fallback"
+            href="mailto:u2679054@uel.ac.uk?subject=Sponsoring%20Eigendrum"
+          >
+            <strong>This space is for rent</strong>
+            <span>Reach real people who draw and solve for fun. Email to sponsor it.</span>
+          </a>
+        </div>
       </div>
 
       <div class="colophon-side">

--- a/src/app/ads.js
+++ b/src/app/ads.js
@@ -272,7 +272,19 @@ export function mountAds() {
   let mounted = 0;
   for (const holder of holders) {
     const frame = holder.querySelector('.ad-frame');
-    if (frame && adapter.unit(frame, holder.dataset.ad, cfg, holder)) mounted += 1;
+    if (!frame) {
+      holder.hidden = true;
+      continue;
+    }
+
+    const fallback = frame.querySelector('.ad-fallback');
+    if (PROVIDER === 'sponsor-wanted' && fallback) {
+      mounted += 1;
+      continue;
+    }
+
+    frame.replaceChildren();
+    if (adapter.unit(frame, holder.dataset.ad, cfg, holder)) mounted += 1;
     else holder.hidden = true;
   }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -218,8 +218,13 @@ h3 {
 }
 
 @media (max-width: 34rem) {
+  .masthead {
+    flex-wrap: wrap;
+  }
   .masthead-live {
-    display: none;
+    order: 3;
+    flex: 1 0 100%;
+    margin: -0.25rem 0 0;
   }
 }
 
@@ -1592,6 +1597,9 @@ dialog form {
   .colophon-side {
     flex-basis: 100%;
     max-width: none;
+  }
+  .ad-home {
+    order: -1;
   }
   .ad-home .ad-frame {
     min-height: 250px;


### PR DESCRIPTION
### Motivation
- The live presence count was hidden on narrow viewports, making the real-time headcount invisible on phones.
- The home footer ad frame showed only a labelled empty slot until JS mounted, leaving mobile visitors with an un-tappable “advertisement” that did nothing.
- When the footer stacks on small screens the ad was positioned after the read-more column, reducing its visibility on mobile.

### Description
- Inserted a tappable sponsorship fallback anchor inside the home footer `.ad-frame` in `index.html` so a usable pitch exists before JS runs. 
- Updated `mountAds()` in `src/app/ads.js` to preserve an `.ad-fallback` when `PROVIDER === 'sponsor-wanted'`, to clear the frame before inserting a real unit for other providers, and to avoid collapsing frames without `.ad-frame`.
- Adjusted `styles/app.css` to allow the `.masthead` to wrap on small screens and to move `.masthead-live` onto its own mobile row, and to reorder `.ad-home` in the stacked footer so the banner appears ahead of the read-more links.

### Testing
- Ran `npm test` (which runs `node tools/check-pages.mjs` and the unit tests) and the suite passed (page audit passed and all automated unit tests passed).
- Verified `node tools/serve.mjs` started the dev server at `http://localhost:8080` for manual checks.
- Attempted the narrow-viewport smoke check via `npm run mobile`, but it failed in this environment because `puppeteer` was not installed and `npm ci` failed while downloading Chromium (network/remote download error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8005d063c48332b7c00dd2bc45e081)